### PR TITLE
Abstract types

### DIFF
--- a/src/com/musicplayer/logic/SingleAlbumLogic.java
+++ b/src/com/musicplayer/logic/SingleAlbumLogic.java
@@ -1,6 +1,6 @@
 package com.musicplayer.logic;
 
-import java.util.ArrayList;
+import java.util.List;
 
 import com.musicplayer.gui.GUI;
 import com.musicplayer.gui.SwingGUI;
@@ -20,9 +20,9 @@ public class SingleAlbumLogic implements Logic {
 	private static Player player;
 	private static final String DEFAULT_ART = "default.png";
 	private static Scanner scanner;
-	private static ArrayList<String> songs;
-	private static ArrayList<String> covers;
-	private static ArrayList<String> images;
+	private static List<String> songs;
+	private static List<String> covers;
+	private static List<String> images;
 	private static String albumArt;
 	private static GUI gui;
 	

--- a/src/com/musicplayer/player/Player.java
+++ b/src/com/musicplayer/player/Player.java
@@ -1,6 +1,6 @@
 package com.musicplayer.player;
 
-import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Defines the minimum framework to implement a player to be a drop-in replacement in Main.
@@ -14,7 +14,7 @@ public interface Player {
 	public void add(String song);
 	// add multiple songs to the play queue
 	// (can technically be done after starting playing)
-	public void addMultiple(ArrayList<String> songs);
+	public void addMultiple(List<String> songs);
 	// start / resume playback
 	public void play();
 	// pause playback

--- a/src/com/musicplayer/player/VLCJListPlayer.java
+++ b/src/com/musicplayer/player/VLCJListPlayer.java
@@ -1,7 +1,7 @@
 package com.musicplayer.player;
 
 
-import java.util.ArrayList;
+import java.util.List;
 
 import com.musicplayer.misc.Helper;
 
@@ -93,7 +93,7 @@ public class VLCJListPlayer implements Player{
 	 * Add multiple songs to the queue (using their path)
 	 * @param songs: arraylist of paths to the audio files
 	 */
-	public void addMultiple(ArrayList<String> songs) {
+	public void addMultiple(List<String> songs) {
 		for(String song : songs)
 			add(song);
 	}

--- a/src/com/musicplayer/scanner/Scanner.java
+++ b/src/com/musicplayer/scanner/Scanner.java
@@ -1,6 +1,6 @@
 package com.musicplayer.scanner;
 
-import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Defines the minimum framework to implement a scanner to be a drop-in replacement in Main.
@@ -9,11 +9,11 @@ import java.util.ArrayList;
  */
 public interface Scanner {
 	// get the cover art to display
-	public ArrayList<String> getCoverArt();
+	public List<String> getCoverArt();
 	// get all the music files to play
-	public ArrayList<String> getAllMusicFiles();
+	public List<String> getAllMusicFiles();
 	// get all the images associated with the content
-	public ArrayList<String> getAllImageFiles();
+	public List<String> getAllImageFiles();
 	// get the name of the album that will be played
 	// (is ideally then replaced by the album gotten from the player)
 	public String getAlbumName();


### PR DESCRIPTION
ArrayList<String> Was changed to List<String> whenever possible to make them more abstract and make different implementations easier.